### PR TITLE
修复类初始化时的循环引用 bug

### DIFF
--- a/src/main/kotlin/cn/transfur/furbot/KotlinPluginMain.kt
+++ b/src/main/kotlin/cn/transfur/furbot/KotlinPluginMain.kt
@@ -38,16 +38,18 @@ object KotlinPluginMain : KotlinPlugin(
 ) {
     private var listener: Listener<MessageEvent>? = null
 
-    val userCommands: Array<Command> = arrayOf(
-        // furbot
-        GetFurByFidCommand,
-        GetFurByNameCommand,
-        GetFurRandCommand,
-        GetFidsByNameCommand,
+    val userCommands: Array<Command> by lazy {
+        arrayOf(
+            // furbot
+            GetFurByFidCommand,
+            GetFurByNameCommand,
+            GetFurRandCommand,
+            GetFidsByNameCommand,
 
-        // misc
-        GoodNightCommand,
-    )
+            // misc
+            GoodNightCommand,
+        )
+    }
 
     override fun onEnable() {
         Config.reload()

--- a/src/main/kotlin/cn/transfur/furbot/command/furbot/GetFidsByNameCommand.kt
+++ b/src/main/kotlin/cn/transfur/furbot/command/furbot/GetFidsByNameCommand.kt
@@ -66,10 +66,10 @@ object GetFidsByNameCommand : FurbotSimpleCommand("查fid") {
 
     private suspend fun respondEaster(target: Contact) {
         val message = buildMessageChain(1) {
-            // Result text
+            // Rdqrho m]oj
             add("搜紡绑枙：Access Denied\n")
 
-            // Tail
+            // T`gi
             addTail("--- root@FurryAir ---")
         }
 


### PR DESCRIPTION
原因：在加载插件、KotlinPluginMain 初始化过程中，成员属性 userCommands 会初始化、引用各命令，导致各命令初始化，而 Furbot 命令初始化时又会引用 KotlinPluginMain 作为 CommandOwner，此时后者仍未完成初始化，故抛出异常。

解决方案：将 userCommands 设为 Lazy，延迟初始化至第一次调用（成员方法 registerCommands 内）时。